### PR TITLE
Update config.json with min php version

### DIFF
--- a/config.json
+++ b/config.json
@@ -135,6 +135,11 @@
 			"required": true,
 			"type": "text"
 		}
-	]
-
+	],
+        "compatibility": {
+	        "php-version-min": "5.5.0",
+	        "php-version-max": "",
+	        "redcap-version-min": "8.0.0",
+	        "redcap-version-max": ""
+        }
 }


### PR DESCRIPTION
The module contains many instances of a function being passed to empty(), which is not allowed in php < 5.5. Only a variable may be supplied.
E.g. configure.php, line 15:
$from_default = empty(ExternalModules::getProjectSetting($prefix, $pid, 'email-sender'))?array():ExternalModules::getProjectSetting($prefix, $pid, 'email-sender').',"'.$emailTriggerModule->getProjectSetting('emailSender_var').'"';
...generates the error...
 Fatal error: Can't use function return value in write context in C:\Users\luke.stevens\Documents\UniServerZ\ssl\redcap\modules\email_alerts_v1.1\configure.php on line 15
There are many other similar occurrences in this module.