### PR TITLE
get surveyLink & returnCode without form status change

### DIFF
--- a/surveyPassthru.php
+++ b/surveyPassthru.php
@@ -6,16 +6,13 @@ use ExternalModules\ExternalModules;
 
 require_once 'EmailTriggerExternalModule.php';
 
-$passthruData = $module->resetSurveyAndGetCodes($_REQUEST['pid'], $_REQUEST['record'], $_REQUEST['instrument'], $_REQUEST['event']);
+$returnCode = \REDCap::getSurveyReturnCode($_REQUEST['record'], $_REQUEST['instrument'], $_REQUEST['event']);
+$surveyLink = \REDCap::getSurveyLink($_REQUEST['record'], $_REQUEST['instrument'], $_REQUEST['event']);
 
-$returnCode = $passthruData['return_code'];
-$hash = $passthruData['hash'];
-if($returnCode == $_REQUEST['returnCode']){
+if(strcasecmp($returnCode, $_REQUEST['returnCode']) == 0) {
 
-    $surveyLink = APP_PATH_SURVEY_FULL."?s=".$hash;
     $link = ($_REQUEST['returnCode'] == "NULL")? "":"<input type='hidden' value='".$returnCode."' name='__code'/>";
     ?>
-
 
     <html>
     <body>


### PR DESCRIPTION
This would resolve issue #28 by removing the usage of `resetSurveyAndGetCodes` to return both the hash and return_code; instead using the REDCap EM functions `getSurveyReturnCode` and `getSurveyLink` instead to obtain this information. 

`getSurveyReturnCode` always returns a forcefully uppercased text string, so the comparison needs to happen in a case-insensitive way. 